### PR TITLE
Add simple embeds for SCUTTLE bot notifications

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,7 +24,6 @@ class Kernel extends ConsoleKernel
      * @var array
      */
     protected $commands = [
-        //
     ];
 
     /**
@@ -48,7 +47,10 @@ class Kernel extends ConsoleKernel
         // 2stacks will shoot back metadata for those pages.
         $schedule->call(function() {
             $fifostring = bin2hex(random_bytes(64));
-            discord("`2stacks-sched-get-page-metas` <:scp:619361872449372200>\nBeginning job ending in ".substr($fifostring,-16)." to send to 2stacks via SQS queue `scuttle-sched-page-updates.fifo`.");
+            discord(
+                '2stacks-sched-get-page-metas',
+                "Beginning job ending in ".substr($fifostring,-16)." to send to 2stacks via SQS queue `scuttle-sched-page-updates.fifo`.",
+            );
             $wikis = Wiki::whereNotNull('metadata->wd_site')->get();
             $slugscount = 0;
             foreach ($wikis as $wiki) {

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -61,7 +61,10 @@ class Kernel extends ConsoleKernel
                             $slugscount++;
                     }
                 };
-            discord("`2stacks-sched-get-page-metas` <:scp:619361872449372200>\n Job ending in ".substr($fifostring,-16)." has been fully sent to SQS, roughly ".($slugscount*100)." pages in scope.");
+            discord(
+                '2stacks-sched-get-page-metas',
+                "Job ending in ".substr($fifostring,-16)." has been fully sent to SQS, roughly ".($slugscount*100)." pages in scope.",
+            );
         })->dailyAt('3:00');
 
         // Once a day, queue requests for fresh vote info for each active page.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -99,19 +99,28 @@ class Kernel extends ConsoleKernel
             $fifostring = bin2hex(random_bytes(64));
             $forums = Forum::all();
 
-            discord("`2stacks-get-forum-threads` <:scp:619361872449372200>\n Job ending in ".substr($fifostring,-16)." has begun.");
+            discord(
+                '2stacks-get-forum-threads',
+                "Job ending in ".substr($fifostring,-16)." has begun.",
+            );
 
             foreach ($forums as $forum) {
                 $job = new PushForumId($forum->wd_forum_id, $forum->wiki_id);
                 $job->send('scuttle-forums-needing-update.fifo', $fifostring);
             }
 
-            discord("`2stacks-get-forum-threads` <:scp:619361872449372200>\n Job ending in ".substr($fifostring,-16)." has been sent to SQS queue `scuttle-forums-needing-update.fifo`.\nForums: ".$forums->count());
+            discord(
+                '2stacks-get-forum-threads',
+                "Job ending in ".substr($fifostring,-16)." has been sent to SQS queue `scuttle-forums-needing-update.fifo`.\nForums: ".$forums->count(),
+            );
         })->dailyAt('22:00');
 
         // Go get all the forums for a particular wikidot site.
         $schedule->call(function() {
-            discord("`2stacks-get-forum-categories` <:scp:619361872449372200>\n Job has begun.");
+            discord(
+                '2stacks-get-forum-categories',
+                "Job has begun.",
+            );
 
             $wikis = Wiki::whereNotNull('metadata->wd_site')->get();
             foreach ($wikis as $wiki) {
@@ -119,13 +128,19 @@ class Kernel extends ConsoleKernel
                 $job->send('scuttle-forums-missing-metadata');
             }
 
-            discord("`2stacks-get-forum-categories` <:scp:619361872449372200>\n Job has been sent to SQS queue `scuttle-forums-missing-metadata`.\nWikis: ".$wikis->count());
+            discord(
+                '2stacks-get-forum-categories',
+                "Job has been sent to SQS queue `scuttle-forums-missing-metadata`.\nWikis: ".$wikis->count(),
+            );
         })->dailyAt('6:00');
 
         // Daily Maintenance:
         // Go find missing revisions daily.
         $schedule->call(function() {
-            discord("`2stacks-get-revision-content` <:scp:619361872449372200>\n Job has begun.");
+            discord(
+                '2stacks-get-revision-content',
+                "Job has begun.",
+            );
 
             $revs = Revision::where('needs_content', 1)->get();
             foreach($revs as $rev) {
@@ -133,7 +148,10 @@ class Kernel extends ConsoleKernel
                 $job->send('scuttle-revisions-missing-content');
             }
 
-            discord("`2stacks-get-revision-content` <:scp:619361872449372200>\n Job has been sent to SQS queue `scuttle-revisions-missing-content`.\n Revisions: ".$revs->count());
+            discord(
+                '2stacks-get-revision-content',
+                "Job has been sent to SQS queue `scuttle-revisions-missing-content`.\n Revisions: ".$revs->count(),
+            );
         })->dailyAt('4:30');
 
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -73,7 +73,10 @@ class Kernel extends ConsoleKernel
             $wikis = Wiki::whereNotNull('metadata->wd_site')->get();
             $fifostring = bin2hex(random_bytes(64));
 
-            discord("`2stacks-queue-vote-job` <:scp:619361872449372200>\n Job ending in ".substr($fifostring,-16)." has begun.");
+            discord(
+                '2stacks-queue-vote-job',
+                "Job ending in ".substr($fifostring,-16)." has begun.",
+            );
             $totalpages = 0;
             foreach ($wikis as $wiki) {
 
@@ -85,7 +88,10 @@ class Kernel extends ConsoleKernel
                 $job->send('scuttle-job-pageid-for-votes.fifo', $fifostring);
             }
 
-            discord("`2stacks-queue-vote-job` <:scp:619361872449372200>\n Job ending in ".substr($fifostring,-16)." has been sent to SQS queue `scuttle-job-pageid-for-votes.fifo`.\nWikis: ".$wikis->count()."\nPages: ".$totalpages);
+            discord(
+                '2stacks-queue-vote-job',
+                "Job ending in ".substr($fifostring,-16)." has been sent to SQS queue `scuttle-job-pageid-for-votes.fifo`.\nWikis: ".$wikis->count()."\nPages: ".$totalpages,
+            );
         })->cron('5 */8 * * *');
 
         // Once a day, get fresh forum posts. This needs to start from the beginning, i.e., checking for the existence of new forums and everything.

--- a/app/Http/Controllers/API/PageController.php
+++ b/app/Http/Controllers/API/PageController.php
@@ -58,7 +58,10 @@ class PageController extends Controller
                     );
                 }
                 else {
-                    discord("`NEW PAGES` <:eyesss:619357671799259147>\nReceived ".count($unaccountedpages)." slugs for domain `" . $domain->domain . "`, dispatching jobs.");
+                    discord(
+                        'new-page',
+                        "Received ".count($unaccountedpages)." slugs for domain `" . $domain->domain . "`, dispatching jobs.",
+                    );
                 }
             }
             // Let's stub out the page and note that we need metadata for the page.
@@ -94,10 +97,16 @@ class PageController extends Controller
                 $fifostring = bin2hex(random_bytes(64));
                 // Ping Discord.
                 if(count($deletedpages) === 1) {
-                    discord("`MISSING PAGE` 🧐\nSlug `".$deletedpages[0]."` for domain `".$domain->domain."` not present in manifest, dispatching job ending in `".substr($fifostring,-16)."`.");
+                    discord(
+                        'missing-page',
+                        "Slug `".$deletedpages[0]."` for domain `".$domain->domain."` not present in manifest, dispatching job ending in `".substr($fifostring,-16)."`.",
+                    );
                 }
                 else {
-                    discord("`MISSING PAGES` 🧐\n ".count($deletedpages)." slugs for domain `" . $domain->domain . "` not present in manifest, dispatching job ending in `".substr($fifostring,-16)."`.");
+                    discord(
+                        'missing-page',
+                        "".count($deletedpages)." slugs for domain `" . $domain->domain . "` not present in manifest, dispatching job ending in `".substr($fifostring,-16)."`.",
+                    );
                 }
             }
 
@@ -110,7 +119,10 @@ class PageController extends Controller
                 if($page->wd_page_id == null) {
                     $metadata = json_decode($page->metadata, true);
                     if(isset($metadata["page_missing"]) && $metadata["page_missing"] == true) {
-                        discord("`PAGE DELETED` <:rip:619357639880605726>\nDeleting ".$page->slug." (SCUTTLE ID `".$page->id."`) after it was flagged missing without a Wikidot page ID to reference.");
+                        discord(
+                            'deleted-page',
+                            "Deleting ".$page->slug." (SCUTTLE ID `".$page->id."`) after it was flagged missing without a Wikidot page ID to reference.",
+                        );
 
                         $page->delete();
                     }

--- a/app/Http/Controllers/API/PageController.php
+++ b/app/Http/Controllers/API/PageController.php
@@ -53,13 +53,13 @@ class PageController extends Controller
                 // Ping Discord.
                 if(count($unaccountedpages) === 1) {
                     discord(
-                        'new-page',
+                        'page-new',
                         "Received slug `".$unaccountedpages[0]."` for domain `".$domain->domain."`, dispatching jobs.",
                     );
                 }
                 else {
                     discord(
-                        'new-page',
+                        'page-new',
                         "Received ".count($unaccountedpages)." slugs for domain `" . $domain->domain . "`, dispatching jobs.",
                     );
                 }
@@ -98,13 +98,13 @@ class PageController extends Controller
                 // Ping Discord.
                 if(count($deletedpages) === 1) {
                     discord(
-                        'missing-page',
+                        'page-missing',
                         "Slug `".$deletedpages[0]."` for domain `".$domain->domain."` not present in manifest, dispatching job ending in `".substr($fifostring,-16)."`.",
                     );
                 }
                 else {
                     discord(
-                        'missing-page',
+                        'page-missing',
                         "".count($deletedpages)." slugs for domain `" . $domain->domain . "` not present in manifest, dispatching job ending in `".substr($fifostring,-16)."`.",
                     );
                 }
@@ -120,7 +120,7 @@ class PageController extends Controller
                     $metadata = json_decode($page->metadata, true);
                     if(isset($metadata["page_missing"]) && $metadata["page_missing"] == true) {
                         discord(
-                            'deleted-page',
+                            'page-deleted',
                             "Deleting ".$page->slug." (SCUTTLE ID `".$page->id."`) after it was flagged missing without a Wikidot page ID to reference.",
                         );
 
@@ -251,13 +251,13 @@ class PageController extends Controller
                 // Ping Discord.
                 if($page->slug != $request["slug"]) {
                     discord(
-                        'moved-page',
+                        'page-moved',
                         "Page with ID `" . $request['wd_page_id'] . "` has been renamed from `" . $page->slug . "` to `" . $request["slug"] . "`. Updating metadata.",
                     );
                 }
                 else {
                     discord(
-                        'updated-page',
+                        'page-updated',
                         "Page with ID `" . $request['wd_page_id'] . "` (`" . $page->slug . "`) received updated metadata from 2stacks.",
                     );
                 }

--- a/app/Http/Controllers/API/PageController.php
+++ b/app/Http/Controllers/API/PageController.php
@@ -250,10 +250,16 @@ class PageController extends Controller
 
                 // Ping Discord.
                 if($page->slug != $request["slug"]) {
-                    discord("`PAGE MOVED` ➡️\nPage with ID `" . $request['wd_page_id'] . "` has been renamed from `" . $page->slug . "` to `" . $request["slug"] . "`. Updating metadata.");
+                    discord(
+                        'moved-page',
+                        "Page with ID `" . $request['wd_page_id'] . "` has been renamed from `" . $page->slug . "` to `" . $request["slug"] . "`. Updating metadata.",
+                    );
                 }
                 else {
-                    discord("`PAGE UPDATED` 🔄️\nPage with ID `" . $request['wd_page_id'] . "` (`" . $page->slug . "`) received updated metadata from 2stacks.");
+                    discord(
+                        'updated-page',
+                        "Page with ID `" . $request['wd_page_id'] . "` (`" . $page->slug . "`) received updated metadata from 2stacks.",
+                    );
                 }
                 $metadata = json_decode($page->metadata, true);
                 if(isset($metadata["old_slugs"])) {

--- a/app/Http/Controllers/API/PageController.php
+++ b/app/Http/Controllers/API/PageController.php
@@ -52,7 +52,10 @@ class PageController extends Controller
             if(count($unaccountedpages) > 0) {
                 // Ping Discord.
                 if(count($unaccountedpages) === 1) {
-                    discord("`NEW PAGE` <:eyesss:619357671799259147>\nReceived slug `".$unaccountedpages[0]."` for domain `".$domain->domain."`, dispatching jobs.");
+                    discord(
+                        'new-page',
+                        "Received slug `".$unaccountedpages[0]."` for domain `".$domain->domain."`, dispatching jobs.",
+                    );
                 }
                 else {
                     discord("`NEW PAGES` <:eyesss:619357671799259147>\nReceived ".count($unaccountedpages)." slugs for domain `" . $domain->domain . "`, dispatching jobs.");

--- a/app/Http/Controllers/API/PageController.php
+++ b/app/Http/Controllers/API/PageController.php
@@ -607,15 +607,18 @@ class PageController extends Controller
                 $page->metadata = json_encode($metadata);
                 $page->delete();
 
-                discord("`PAGE DELETED` <:rip:619357639880605726>\nDeleting ".$metadata["wikidot_metadata"]["title"]." (SCUTTLE ID `".$page->id."`) after it was flagged missing and then not found at Wikidot.");
-
-
+                discord(
+                    'page-deleted',
+                    "Deleting ".$metadata["wikidot_metadata"]["title"]." (SCUTTLE ID `".$page->id."`) after it was flagged missing and then not found at Wikidot.",
+                );
             }
-
             else {
                 // Now this is concerning. We got an instruction to delete a page that came from outside the normal workflow.
                 // Fire a notification to investigate.
-                discord("`SECURITY ADVISORY` <:ping:619357511081787393>\n<@350660518408880128>:0001 SCUTTLE received a request to delete page ".$metadata["wikidot_metadata"]["title"]." (SCUTTLE ID `".$page->id."`) but it is not flagged as missing.\nIP address: `".$request->ip()."`\nUser ID: ".auth()->id());
+                discord(
+                    'security',
+                    "<@350660518408880128> SCUTTLE received a request to delete page ".$metadata["wikidot_metadata"]["title"]." (SCUTTLE ID `".$page->id."`) but it is not flagged as missing.\nIP address: `".$request->ip()."`\nUser ID: ".auth()->id(),
+                );
             }
         }
     }

--- a/app/Notifications/PostJobStatusToDiscord.php
+++ b/app/Notifications/PostJobStatusToDiscord.php
@@ -11,16 +11,16 @@ use NotificationChannels\Discord\DiscordMessage;
 
 class PostJobStatusToDiscord extends Notification
 {
-    public $body;
+    public $embed;
 
     /**
      * Create a new notification instance.
      *
      * @return void
      */
-    public function __construct($body)
+    public function __construct($embed)
     {
-        $this->body = $body;
+        $this->embed = $embed;
     }
 
     /**
@@ -36,6 +36,6 @@ class PostJobStatusToDiscord extends Notification
 
     public function toDiscord($notifiable)
     {
-        return DiscordMessage::create($this->body);
+        return DiscordMessage::create('', $this->embed);
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -4,8 +4,7 @@ use App\Notifications\PostJobStatusToDiscord;
 use Illuminate\Support\Facades\Notification;
 
 function discord($message): void {
-    Notification::route('discord', env('DISCORD_BOT_CHANNEL'))->notify(new PostJobStatusToDiscord(
-        $message
-    ));
+    $job = new PostJobStatusToDiscord($message);
+    Notification::route('discord', env('DISCORD_BOT_CHANNEL'))->notify($job);
     return;
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -10,6 +10,10 @@ $messageTypes = [
         'title' => 'Page Metadata Job',
         'emoji' => '<:scp:619361872449372200>',
     ],
+    '2stacks-queue-vote-job' => [
+        'title' => 'Page Vote Job',
+        'emoji' => '<:scp:619361872449372200>',
+    ],
     'new-page' => [
         'title' => 'New Page',
         'emoji' => '',

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -30,6 +30,14 @@ $messageTypes = [
         'title' => 'New Page',
         'emoji' => '<:eyesss:619357671799259147>',
     ],
+    'missing-page' => [
+        'title' => 'Missing Page',
+        'emoji' => '🧐',
+    ],
+    'deleted-page' => [
+        'title' => 'Deleted Page',
+        'emoji' => '<:rip:619357639880605726>',
+    ],
 ];
 
 function discord($type, $message): void {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -3,8 +3,25 @@
 use App\Notifications\PostJobStatusToDiscord;
 use Illuminate\Support\Facades\Notification;
 
-function discord($message): void {
-    $job = new PostJobStatusToDiscord($message);
+$embedColor = 6513507; // hex #999
+
+$messageTypes = [
+    'new-page' => [
+        'title' => 'New Page',
+        'emoji' => '',
+    ],
+];
+
+function discord($type, $message): void {
+    $template = $messageTypes[$type];
+
+    $embed = (object) [
+        'title' => "**$template->title**",
+        'description' => "$template->emoji $message",
+        'color' => $embedColor,
+    ];
+
+    $job = new PostJobStatusToDiscord($embed);
     Notification::route('discord', env('DISCORD_BOT_CHANNEL'))->notify($job);
     return;
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -6,6 +6,10 @@ use Illuminate\Support\Facades\Notification;
 $embedColor = 6513507; // hex #999
 
 $messageTypes = [
+    '2stacks-sched-get-page-metas' => [
+        'title' => 'Scheduled Page Metadata Job',
+        'emoji' => '<:scp:619361872449372200>',
+    ],
     'new-page' => [
         'title' => 'New Page',
         'emoji' => '',

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -46,6 +46,10 @@ $messageTypes = [
         'title' => 'Page Updated',
         'emoji' => '🔄️',
     ],
+    'security' => [
+        'title' => 'Security Advisory',
+        'emoji' => '<:ping:619357511081787393>',
+    ],
 ];
 
 function discord($type, $message): void {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -35,8 +35,16 @@ $messageTypes = [
         'emoji' => '🧐',
     ],
     'deleted-page' => [
-        'title' => 'Deleted Page',
+        'title' => 'Page Deleted',
         'emoji' => '<:rip:619357639880605726>',
+    ],
+    'moved-page' => [
+        'title' => 'Page Moved',
+        'emoji' => '➡️',
+    ],
+    'updated-page' => [
+        'title' => 'Page Updated',
+        'emoji' => '🔄️',
     ],
 ];
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -14,6 +14,18 @@ $messageTypes = [
         'title' => 'Page Vote Job',
         'emoji' => '<:scp:619361872449372200>',
     ],
+    '2stacks-get-forum-threads' => [
+        'title' => 'Forum Thread Job',
+        'emoji' => '<:scp:619361872449372200>',
+    ],
+    '2stacks-get-forum-categories' => [
+        'title' => 'Forum Category Job',
+        'emoji' => '<:scp:619361872449372200>',
+    ],
+    '2stacks-get-revision-content' => [
+        'title' => 'Revision Content Job',
+        'emoji' => '<:scp:619361872449372200>',
+    ],
     'new-page' => [
         'title' => 'New Page',
         'emoji' => '',

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -26,23 +26,23 @@ $messageTypes = [
         'title' => 'Revision Content Job',
         'emoji' => '<:scp:619361872449372200>',
     ],
-    'new-page' => [
+    'page-new' => [
         'title' => 'New Page',
         'emoji' => '<:eyesss:619357671799259147>',
     ],
-    'missing-page' => [
+    'page-mising' => [
         'title' => 'Missing Page',
         'emoji' => '🧐',
     ],
-    'deleted-page' => [
+    'page-deleted' => [
         'title' => 'Page Deleted',
         'emoji' => '<:rip:619357639880605726>',
     ],
-    'moved-page' => [
+    'page-moved' => [
         'title' => 'Page Moved',
         'emoji' => '➡️',
     ],
-    'updated-page' => [
+    'page-updated' => [
         'title' => 'Page Updated',
         'emoji' => '🔄️',
     ],

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -7,7 +7,7 @@ $embedColor = 6513507; // hex #999
 
 $messageTypes = [
     '2stacks-sched-get-page-metas' => [
-        'title' => 'Scheduled Page Metadata Job',
+        'title' => 'Page Metadata Job',
         'emoji' => '<:scp:619361872449372200>',
     ],
     'new-page' => [

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -28,7 +28,7 @@ $messageTypes = [
     ],
     'new-page' => [
         'title' => 'New Page',
-        'emoji' => '',
+        'emoji' => '<:eyesss:619357671799259147>',
     ],
 ];
 


### PR DESCRIPTION
Adds an "enum" with notification types that store the emoji and title.

The description is passed in as-is according to the formatting of the caller.