### PR TITLE
Add posts since timestamp endpoint

### DIFF
--- a/app/Http/Controllers/API/v1/PostController.php
+++ b/app/Http/Controllers/API/v1/PostController.php
@@ -6,7 +6,10 @@ use App\Post;
 use App\Http\Controllers\Controller;
 use App\Domain;
 use App\Forum;
+use Illuminate\Validation\Rule;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
 
 class PostController extends Controller
@@ -26,6 +29,53 @@ class PostController extends Controller
         // We're not returning a different status in the interest of customer privacy.
         $post->metadata = json_decode($post->metadata, true);
         return $post;
+    }
+
+    public function post_get_post_since_TIMESTAMP(Domain $domain, $timestamp)
+    {
+        $rule['timestamp'] = $timestamp;
+        Validator::make($rule, [
+            'timestamp' => 'required|integer|min:0',
+        ])->validate();
+
+        $posts = DB::table('posts')
+            ->select('id', 'parent_id', 'wd_post_id', 'wd_parent_id')
+            ->where('wiki_id', $domain->wiki_id)
+            ->where('metadata->wd_timestamp', '>', $timestamp)
+            ->whereNull('deleted_at')
+            ->orderBy('metadata->wd_timestamp')
+            ->get();
+        $payload = $posts->toJson();
+        return response($payload)->header('Content-Type', 'application/json');
+    }
+
+    public function post_post_post_since_TIMESTAMP(Domain $domain, Request $request, $timestamp)
+    {
+        $request['timestamp'] = $timestamp;
+        Validator::make($request->all(), [
+            'timestamp' => 'required|integer|min:0',
+            'limit' => 'nullable|integer|min:1|max:100',
+            'offset' => 'nullable|integer|min:0',
+            'direction' => ['nullable', Rule::in(['asc','desc'])],
+        ])->validate();
+
+        $limit = $request->limit ?? 20;
+        $offset = $request->offset ?? 0;
+        $direction = $request->direction ?? 'asc';
+
+        $posts = DB::table('posts')
+            ->where('wiki_id', $domain->wiki_id)
+            ->where('metadata->wd_timestamp', '>', $timestamp)
+            ->whereNull('deleted_at')
+            ->orderBy('metadata->wd_timestamp', $direction)
+            ->limit($limit)
+            ->offset($offset)
+            ->get();
+        foreach($posts as $post) {
+            $post->metadata = json_decode($post->metadata, true);
+        }
+        $payload = $posts->toJson();
+        return response($payload)->header('Content-Type', 'application/json');
     }
 
     public function post_get_post_ID(Domain $domain, $id)

--- a/app/Http/Controllers/API/v1/PostController.php
+++ b/app/Http/Controllers/API/v1/PostController.php
@@ -39,7 +39,7 @@ class PostController extends Controller
         ])->validate();
 
         $posts = DB::table('posts')
-            ->select('id', 'parent_id', 'wd_post_id', 'wd_parent_id')
+            ->select('id', 'parent_id', 'wd_post_id', 'wd_parent_id', 'thread_id')
             ->where('wiki_id', $domain->wiki_id)
             ->where('metadata->wd_timestamp', '>', $timestamp)
             ->whereNull('deleted_at')

--- a/routes/api.php
+++ b/routes/api.php
@@ -88,6 +88,8 @@ Route::middleware('auth:api', 'throttle:10000,1')->group(function() {
             Route::post('thread/{id}/since/{timestamp}', 'API\v1\ThreadController@thread_post_thread_ID_since_TIMESTAMP')->middleware('scope:read-post');
 
             // Post Namespace
+            Route::get('post/since/{timestamp}', 'API\v1\PostController@post_get_post_since_TIMESTAMP')->middleware('scope:read-post');
+            Route::post('post/since/{timestamp}', 'API\v1\PostController@post_post_post_since_TIMESTAMP')->middleware('scope:read-post');
             Route::get('post/{id}', 'API\v1\PostController@post_get_post_ID')->middleware('scope:read-post');
             Route::get('post/{id}/children', 'API\v1\PostController@post_get_post_ID_children')->middleware('scope:read-post');
             Route::get('post/{id}/parent', 'API\v1\PostController@post_get_post_ID_parent')->middleware('scope:read-post');

--- a/tests/Feature/PostsSinceTimestampTest.php
+++ b/tests/Feature/PostsSinceTimestampTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature;
+
+use Laravel\Passport\Passport;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use App\User;
+
+class PostsSinceTimestampTest extends TestCase {
+
+    use DatabaseTransactions;
+
+    /** @test */
+    public function get_posts_since_timestamp_in_v1_API()
+    {
+        # Given an authenticated user with access to the read-metadata and read-article scopes...
+        Passport::actingAs(factory(User::class)->create(),['read-post']);
+
+        # When an illegal timestamp is sent...
+        $timestamp = "cats";
+        $response = $this->getJson("/api/v1/post/since/$timestamp");
+
+        # Then an HTTP 422 Unprocessable Entity response is returned, with an explanation.
+        $response->assertStatus(422);
+
+        ###
+
+        # When a valid timestamp (2020-06-12) is sent...
+        $timestamp = 1591994817;
+        $response = $this->getJson("/api/v1/post/since/$timestamp");
+
+        # Then we get a valid payload.
+        $response->assertStatus(200);
+        $this->assertJson($response->content());
+
+        ###
+
+        # When we take the value of an item returned and look it up via a different API route...
+        $payload = json_decode($response->getContent(), true);
+        $postId = $payload[0]['id'];
+        $response = $this->get("/api/v1/post/$postId");
+        $retrievedPost = json_decode($response->getContent(), true);
+
+        # Then we will receive more information about the same post as what was in our digest.
+        $this->assertEquals($retrievedPost['id'], $postId);
+        $this->assertEquals($retrievedPost['wd_post_id'], $payload[0]['wd_post_id']);
+    }
+
+    /** @test */
+    public function post_posts_since_timestamp_in_v1_API()
+    {
+        # Given an authenticated user with access to the read-metadata and read-article scopes...
+        Passport::actingAs(factory(User::class)->create(),['read-post']);
+
+        # When an illegal timestamp is sent in the URI...
+        $timestamp = "cats";
+        $response = $this->postJson("/api/v1/post/since/$timestamp");
+
+        # Then an HTTP 422 Unprocessable Entity response is returned, with an explanation.
+        $response->assertStatus(422);
+
+        ###
+
+        # When a valid timestamp (2020-06-12) is sent...
+        $timestamp = 1591994817;
+        $response = $this->postJson("/api/v1/post/since/$timestamp");
+
+        # Then we get a valid payload.
+        $response->assertStatus(200);
+        $this->assertJson($response->content());
+
+        ###
+
+        # When we take the value of an item returned and look it up via a different API route...
+        $payload = json_decode($response->getContent(), true);
+        $postId = $payload[0]['id'];
+        $response = $this->get("/api/v1/post/$postId");
+        $retrievedPost = json_decode($response->getContent(), true);
+
+        # Then we will receive more information about the same post as what was in our digest.
+        $this->assertEquals($retrievedPost['id'], $postId);
+        $this->assertEquals($retrievedPost['wd_post_id'], $payload[0]['wd_post_id']);
+
+        ###
+
+        # When we use an explicit limit...
+        $response = $this->postJson("/api/v1/post/since/$timestamp", [
+            'limit' => 3
+        ]);
+
+        # Then we will get that many items back.
+        $this->assertCount(3, json_decode($response->getContent(), true));
+
+        ###
+
+        # When we use illegal arguments in the post...
+        $response = $this->postJson("/api/v1/post/since/$timestamp", [
+            'limit' => 9999,
+            'offset' => -36,
+            'direction' => 'nope',
+        ]);
+
+        # Then we will get a 422 instead.
+        $response->assertStatus(422);
+    }
+}


### PR DESCRIPTION
This PR adds a `post/since/{timestamp}` endpoint, which returns all posts made on a domain since the given timestamp. I believe this closes [HELP-12](https://scuttle.atlassian.net/browse/HELP-12).

The GET method returns a single list of post IDs, along with parent IDs and the thread ID for each post. The POST method is paginated and returns full information for the selected posts.

The new methods in the post namespace use the database-accessing syntax rather than the Validator syntax. There weren't endpoints in the post namespace that use that syntax, so I had to go looking for the database columns and such. I'm going off of what I found in database/migrations (the helpful file names are appreciated), but it might not be quite right.

As we discussed the other day, not all posts have a wd_timestamp in the database, so this approach will rely on that issue being fixed. In the meantime it'll return data for the few posts that do have wd_timestamp, I assume.

Like #29, I've written the code and the test for it, but I don't know how to actually run it.